### PR TITLE
Added new clear methods

### DIFF
--- a/src/button-toggle.js
+++ b/src/button-toggle.js
@@ -335,6 +335,15 @@ var ButtonToggle = FormElement.extend({
     },
 
     /**
+     * Deselects all toggles.
+     */
+    clear: function () {
+        this._triggerAll(function (formElement, UIElement, idx) {
+            this.deselect(idx);
+        }.bind(this));
+    },
+
+    /**
      * Enables the button toggle.
      */
     enable: function () {

--- a/src/checkbox.js
+++ b/src/checkbox.js
@@ -183,6 +183,13 @@ var Checkbox = FormElement.extend({
     },
 
     /**
+     * Unselects the checkbox if its selected.
+     */
+    clear: function () {
+        this.uncheck();
+    },
+
+    /**
      * Destruction of this class.
      */
     destroy: function () {

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -645,12 +645,10 @@ var Dropdown = FormElement.extend({
 
     /**
      * Clears all options in the dropdown.
+     * @deprecated since 1.8.3
      */
     clearOptions: function () {
-        var uiOptionsContainer = this.getUIElement().getElementsByClassName(this.options.optionsContainerClass)[0],
-            formEl = this.getFormElement();
-        formEl.innerHTML = '';
-        uiOptionsContainer.innerHTML = '';
+        this.clear();
     },
 
     /**
@@ -691,6 +689,16 @@ var Dropdown = FormElement.extend({
     enable: function () {
         this.getUIElement().kit.classList.remove(this.options.disabledClass);
         this.getFormElement().disabled = false;
+    },
+
+    /**
+     * Clears all options in the dropdown
+     */
+    clear: function () {
+        var uiOptionsContainer = this.getUIElement().getElementsByClassName(this.options.optionsContainerClass)[0],
+            formEl = this.getFormElement();
+        formEl.innerHTML = '';
+        uiOptionsContainer.innerHTML = '';
     },
 
     /**

--- a/src/form-element.js
+++ b/src/form-element.js
@@ -54,6 +54,11 @@ var FormElement = Module.extend({
     },
 
     /**
+     * Clears the element.
+     */
+    clear: function () {},
+
+    /**
      * Gets the ui versions of the form elements.
      * @returns {Array} Returns the array of ui-versions of the element.
      * @abstract

--- a/src/form.js
+++ b/src/form.js
@@ -279,6 +279,13 @@ var Form = Module.extend({
     },
 
     /**
+     * Clears all form items.
+     */
+    clear: function () {
+        this.triggerMethodAll('clear');
+    },
+
+    /**
      * Gets an object that maps all fields to their current name/value pairs.
      * @returns {Array} Returns an array of objects
      */

--- a/src/input-field.js
+++ b/src/input-field.js
@@ -234,6 +234,13 @@ var InputField = FormElement.extend({
     },
 
     /**
+     * Sets the input to nothing.
+     */
+    clear: function () {
+        this.setValue('');
+    },
+
+    /**
      * Gets the unique identifier for input fields.
      * @returns {string}
      */

--- a/tests/dropdown-tests.js
+++ b/tests/dropdown-tests.js
@@ -451,7 +451,7 @@ module.exports = (function (){
         fixture.appendChild(selectEl);
         var uiContainerClass = 'my-ui-container';
         var uiOptionsClass = 'my-option';
-        var clearOptionsSpy = Sinon.spy(Dropdown.prototype, 'clearOptions');
+        var clearOptionsSpy = Sinon.spy(Dropdown.prototype, 'clear');
         var dropdown = new Dropdown({
             el: selectEl,
             containerClass: uiContainerClass,
@@ -470,7 +470,7 @@ module.exports = (function (){
         dropdown.destroy();
     });
 
-    QUnit.test('clearOptions() should clear all form and ui options in the dropdown', function() {
+    QUnit.test('clear() should clear all form and ui options in the dropdown', function() {
         QUnit.expect(2);
         var fixture = document.getElementById('qunit-fixture');
         var html =
@@ -487,7 +487,7 @@ module.exports = (function (){
             containerClass: uiContainerClass,
             optionsClass: uiOptionsClass
         });
-        dropdown.clearOptions();
+        dropdown.clear();
         var formOptionElements = fixture.getElementsByTagName('option');
         var uiOptionElements = fixture.getElementsByClassName(uiOptionsClass);
         QUnit.equal(formOptionElements.length, 0, 'all form elements have been cleared');


### PR DESCRIPTION
Now simplying calling .clear() on a Form instance will clear all form values. 